### PR TITLE
Add security guidance and lock controls on login page

### DIFF
--- a/nossa-viagem/pages/login.html
+++ b/nossa-viagem/pages/login.html
@@ -53,15 +53,79 @@
     </section>
 
     
-    <form class="form__login">
+    <form class="form__login" aria-labelledby="secao-login">
         <div class="card">
-             Acesse com seu E-mail:<input type="email" class="email__login" placeholder="Digite seu E-mail">
-             Digite sua Senha:<input type="password" class="senha__login" placeholder="Digite sua Senha">
-            <input type="submit" value="Login" class="button__login">
+            <h2 id="secao-login" class="card__titulo">Acesse sua conta</h2>
+            <label class="card__rotulo" for="login-email">Acesse com seu E-mail:</label>
+            <input type="email" id="login-email" class="email__login" placeholder="Digite seu E-mail" autocomplete="username">
+            <label class="card__rotulo" for="login-senha">Digite sua Senha:</label>
+            <input type="password" id="login-senha" class="senha__login" placeholder="Digite sua Senha" autocomplete="current-password">
+            <div class="card__acoes">
+                <input type="submit" value="Login" class="button__login">
+                <button type="button" class="button__bloquear" aria-live="polite">Bloquear edição</button>
+            </div>
+            <p class="status__bloqueio" role="status">Campos liberados para edição.</p>
             <a href="" class="esqueceu__senha" >Esqueçeu a senha?</a>
             <a href="" class="criar__login">Não tem conta?</a>
         </div>
+
+        <section class="card card--seguranca" aria-labelledby="card-seguranca">
+            <h3 id="card-seguranca" class="card__titulo">Checklist de segurança</h3>
+            <p class="card__descricao">Reforçamos alguns cuidados para manter sua conta protegida.</p>
+            <ul class="card__lista">
+                <li>Revise as permissões dos dispositivos conectados periodicamente.</li>
+                <li>Cheque se seu e-mail aparece em algum vazamento conhecido antes de fazer login.</li>
+                <li>Bloqueie a edição dos campos quando precisar se afastar do computador.</li>
+            </ul>
+            <button type="button" class="button__checar" aria-describedby="card-seguranca">Checar vazamento</button>
+            <p class="card__alerta" role="alert" aria-live="assertive"></p>
+        </section>
     </form>
+
+    <script>
+        (function () {
+            const emailInput = document.querySelector('.email__login');
+            const passwordInput = document.querySelector('.senha__login');
+            const bloquearBotao = document.querySelector('.button__bloquear');
+            const statusBloqueio = document.querySelector('.status__bloqueio');
+            const checarBotao = document.querySelector('.button__checar');
+            const alerta = document.querySelector('.card__alerta');
+
+            const leakedDomains = ['example.com', 'test.com', 'demo.com'];
+            let locked = false;
+
+            bloquearBotao.addEventListener('click', () => {
+                locked = !locked;
+                [emailInput, passwordInput].forEach((campo) => {
+                    campo.readOnly = locked;
+                    campo.setAttribute('aria-readonly', locked ? 'true' : 'false');
+                });
+                bloquearBotao.textContent = locked ? 'Desbloquear edição' : 'Bloquear edição';
+                statusBloqueio.textContent = locked ? 'Edição bloqueada. Clique novamente para liberar os campos.' : 'Campos liberados para edição.';
+            });
+
+            checarBotao.addEventListener('click', () => {
+                const email = emailInput.value.trim().toLowerCase();
+
+                if (!email) {
+                    alerta.textContent = 'Informe um e-mail para verificarmos se há registro em vazamentos públicos.';
+                    alerta.classList.add('card__alerta--visivel');
+                    return;
+                }
+
+                const dominio = email.split('@')[1] || '';
+                const possuiVazamento = leakedDomains.includes(dominio);
+
+                if (possuiVazamento) {
+                    alerta.textContent = 'Atenção: encontramos registros públicos de vazamento associados a este domínio. Considere atualizar sua senha.';
+                } else {
+                    alerta.textContent = 'Nenhum vazamento conhecido encontrado para o domínio informado. Continue monitorando regularmente.';
+                }
+
+                alerta.classList.add('card__alerta--visivel');
+            });
+        })();
+    </script>
 
     <footer class="footer__bg">
         <div class="footer container">

--- a/nossa-viagem/styles/login.css
+++ b/nossa-viagem/styles/login.css
@@ -4,64 +4,169 @@
    justify-content: right;
 }
 
-.email__login {
-   display: flex;
-   align-items: center;
-   justify-content: center;
-   width: 100%;
-	height: 40px;
-   margin: 10px;
-	
-}
-
+.email__login,
 .senha__login {
    display: flex;
    align-items: center;
    justify-content: center;
    width: 100%;
-	height: 40px;
-   margin: 10px;
+   height: 40px;
+   margin: 10px 0;
+   padding: 8px 12px;
+   border-radius: 8px;
+   border: 1px solid rgba(3, 62, 140, 0.4);
+   font-size: 16px;
 }
 
 .form__login{
    display: flex;
-   align-items: center;
+   flex-wrap: wrap;
+   gap: 32px;
+   align-items: flex-start;
    justify-content: center;
-   text-align: center;
+   text-align: left;
    color: #033E8C;
-   font-size: 25px;
-   height: 70vh;
-   font-weight: 600;
+   font-size: 18px;
+   margin: 40px auto 80px;
 }
 
 .card {
-   text-justify: inherit;
-   border-radius: 10px;
-   padding: 40px;
-   width: 700px;
-   font-weight: 600;
+   background: #ffffff;
+   border-radius: 16px;
+   box-shadow: 0 8px 24px rgba(3, 62, 140, 0.08);
+   padding: 32px;
+   width: min(420px, 90vw);
+   font-weight: 500;
+   display: flex;
+   flex-direction: column;
+   gap: 16px;
+}
+
+.card--seguranca {
+   background: #f5f9ff;
+   border: 1px solid rgba(3, 62, 140, 0.1);
+}
+
+.card__titulo {
+   font-size: 24px;
+   font-weight: 700;
+   margin-bottom: 8px;
+}
+
+.card__rotulo {
+   font-size: 14px;
+   text-transform: uppercase;
+   letter-spacing: 0.08em;
+   color: #021e43;
+}
+
+.card__acoes {
+   display: flex;
+   flex-wrap: wrap;
+   gap: 12px;
+   align-items: center;
+}
+
+.button__login,
+.button__bloquear,
+.button__checar {
+   border: none;
+   border-radius: 8px;
+   padding: 12px 20px;
+   font-size: 16px;
+   cursor: pointer;
+   transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .button__login {
-   width: 100%;
-   height: 40px;
-   margin: 10px;
+   flex: 1 1 160px;
    color: #e4e7eb;
    background:#033E8C;
 }
 
-.esqueceu__senha {
-   text-align: center;
-   font-size: 12px;
+.button__bloquear {
+   background: #f0f4ff;
+   color: #033E8C;
+   border: 1px solid rgba(3, 62, 140, 0.4);
+}
+
+.button__checar {
+   align-self: flex-start;
+   background: #033E8C;
+   color: #fff;
+}
+
+.button__login:hover,
+.button__bloquear:hover,
+.button__checar:hover {
+   transform: translateY(-1px);
+}
+
+.button__login:hover,
+.button__checar:hover {
+   background: #012d63;
+}
+
+.button__bloquear:hover {
+   background: rgba(3, 62, 140, 0.1);
+}
+
+.status__bloqueio {
+   font-size: 14px;
+   color: #021e43;
+}
+
+.card__descricao {
+   font-size: 16px;
+   line-height: 1.5;
+}
+
+.card__lista {
+   padding-left: 20px;
+   display: flex;
+   flex-direction: column;
+   gap: 8px;
+   font-size: 15px;
+}
+
+.card__alerta {
+   display: none;
+   font-size: 15px;
+   background: #fff;
+   border-left: 4px solid #033E8C;
+   padding: 12px;
+   border-radius: 6px;
+}
+
+.card__alerta--visivel {
+   display: block;
+}
+
+.esqueceu__senha,
+.criar__login {
+   font-size: 14px;
    opacity: 0.8;
    color: #033E8C;
    text-decoration: none;
 }
 
-.criar__login {
-   text-align: center;
-   font-size: 12px;
-   opacity: 0.8;
-   color: #033E8C;
-   text-decoration: none;
+.esqueceu__senha:hover,
+.criar__login:hover {
+   text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+   .form__login {
+      gap: 24px;
+      font-size: 16px;
+      margin: 32px auto 60px;
+   }
+
+   .card__titulo {
+      font-size: 22px;
+   }
+
+   .card {
+      padding: 24px;
+   }
 }


### PR DESCRIPTION
## Summary
- add an accessibility-friendly login card with a toggle to bloquear edição dos campos
- introduce a security checklist and simulated vazamento check guidance for revising permissões
- refresh login layout styles to support the new cards and action buttons

## Testing
- Manual verification of /pages/login.html in local browser

------
https://chatgpt.com/codex/tasks/task_e_68dfe6957d34832aa87f888ced2119ee